### PR TITLE
enhance SDK pipeline, collection, and schema APIs to support AIDP transcribe

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -23,7 +23,7 @@ admin_client = DIAdminClient(
 **Use DIAdminClient for:**
 - Creating/deleting pipelines and collections
 - Assigning/unassigning buckets
-- Managing schemas and embedding models
+- Listing/getting schemas and managing embedding models
 
 ---
 
@@ -59,7 +59,8 @@ print(schemas_response)
 
 You can inspect the schema names and details to choose the appropriate schema for your pipeline.
 
-**Note: Currently creating new schemas is not supported. Require to use existing schemas available by default**
+**Schema API support in SDK:**
+- Supported: `get_all_schemas()`, `get_schema(name=...)`
 
 
 ---
@@ -130,9 +131,25 @@ print(pipeline_response)
 #     message="Pipeline 'example_rag_pipeline' created successfully."
 # )
 ```
-**NOTE:**  
-- For pipeline_type = "rag" (RAG workflows), `model` & `event_filter_max_object_size` are required. `schema` is optional and `custom_fuc` is not supported.
-- For metadata pipelines, `custom_func` is required. `schema` & `event_filter_max_object_size` are optional and `model` is not supported.
+You can also create a transcribe pipeline:
+
+```python
+pipeline_response = admin_client.create_pipeline(
+    name="example_transcribe_pipeline",
+    pipeline_type="transcribe-metadata",
+    model="supported_transcribe_model",
+    event_filter_object_suffix=["*.jpg", "*.png", "*.jpeg"],
+    event_filter_max_object_size=10737418240,  # Optional: max file size in bytes
+    schema="your_transcribe_schema",  # Use a transcribe-compatible schema
+    prompt="Extract text from image files.",
+)
+```
+
+**NOTE:**
+- For `pipeline_type = "rag"` (RAG workflows), `model` and `event_filter_max_object_size` are required. `schema` is optional and `custom_func` is not supported.
+- For metadata pipelines, `custom_func` is required. `schema` and `event_filter_max_object_size` are optional and `model` is not supported.
+- For `pipeline_type="rag"`, use `chunk_size` and `chunk_overlap` as needed for chunking behavior.
+- For `pipeline_type="transcribe-metadata"`, provide a transcribe `prompt`, choose a model supported by your deployment, and use a transcribe-compatible schema.
 ---
 
 ## 6. Creating a Collection (Admin)
@@ -144,7 +161,7 @@ Collections are logical groupings of data that use a pipeline for ingestion and 
 collection_response = admin_client.create_collection(
     name="example_collection",
     pipeline="example_rag_pipeline",
-    buckets=[]  # You can assign buckets now or later
+    buckets=[],  # You can assign buckets now or later
 )
 
 print(collection_response)
@@ -153,6 +170,17 @@ print(collection_response)
 #     pipeline="example_rag_pipeline",
 #     buckets=[]
 # )
+```
+
+For transcribe collections, set `output_store` to the destination bucket where transcription output is written:
+
+```python
+collection_response = admin_client.create_collection(
+    name="example_transcribe_collection",
+    pipeline="example_transcribe_pipeline",
+    buckets=["example-input-bucket"],
+    output_store="example-output-bucket",
+)
 ```
 
 ---

--- a/pydi_client/api/collection.py
+++ b/pydi_client/api/collection.py
@@ -11,9 +11,6 @@ from pydi_client.data.collection_manager import (
     ListCollection,
 )
 from pydi_client.data.pipeline import BucketUpdateResponse
-from pydi_client.errors import (
-    NotImplementedException,
-)
 from pydi_client.api.utils import execute_with_retry, build_response
 from pydi_client.logger import get_logger  # Importing the logger utility
 
@@ -92,16 +89,20 @@ class CollectionAPI:
         name: str,
         pipeline: str,
         buckets: Optional[Union[Any, List[str]]] = [],
+        output_store: Optional[str] = None,
+        indexing_mode: Optional[str] = None,
     ) -> V1CollectionResponse:
         logger.info("Creating collection with name: %s, pipeline: %s", name, pipeline)
         body = V1CreateCollection(
             name=name,
             pipeline=pipeline,
             buckets=buckets,
+            outputStore=output_store,
+            indexingMode=indexing_mode,
         )
 
         kwargs: Dict[str, Any] = MethodFactory().create_collection()
-        kwargs["json"] = body.model_dump()
+        kwargs["json"] = body.model_dump(exclude_none=True)
 
         logger.debug("Request payload for create_collection: %s", kwargs)
         response = execute_with_retry(

--- a/pydi_client/api/pipeline.py
+++ b/pydi_client/api/pipeline.py
@@ -76,10 +76,13 @@ class PipelineAPI:
         name: str,
         pipeline_type: str,
         event_filter_object_suffix: List[str],
-        event_filter_max_object_size: int,
+        event_filter_max_object_size: Optional[int] = None,
         schema: Optional[str] = None,
         model: Optional[str] = None,
         custom_func: Optional[str] = None,
+        prompt: Optional[str] = None,
+        chunk_size: Optional[int] = None,
+        chunk_overlap: Optional[int] = None,
     ) -> V1CreatePipelineResponse:
         """
         Create a new pipeline.
@@ -106,10 +109,13 @@ class PipelineAPI:
             eventFilter=filter_item,
             schema=schema,
             customFunction=custom_func,
+            prompt=prompt,
+            chunkSize=chunk_size,
+            chunkOverlap=chunk_overlap,
         )
 
         kwargs: Dict[str, Any] = MethodFactory().create_pipeline()
-        kwargs["json"] = body.model_dump(exclude_none=True)
+        kwargs["json"] = body.model_dump(exclude_none=True, by_alias=True)
 
         logger.debug("Request payload for create_pipeline: %s", kwargs)
         response = execute_with_retry(

--- a/pydi_client/data/collection_manager.py
+++ b/pydi_client/data/collection_manager.py
@@ -1,6 +1,6 @@
 # Copyright Hewlett Packard Enterprise Development LP
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 from typing import List, Dict, Optional, Any
 
 
@@ -41,10 +41,20 @@ class V1CreateCollection(BaseModel):
         name (str): Name of the collection.
         pipeline (str): Pipeline associated with the collection.
         buckets (Optional[List[str]]): Optional list of buckets associated with the collection.
+        outputStore (Optional[str]): Output bucket for transcription results (transcribe usecase).
+        indexingMode (Optional[str]): Indexing mode for RAG collections (e.g., HNSW, GPU_CAGRA). Auto-detected if omitted.
     """
     name: str
     pipeline: str
     buckets: Optional[List[str]]
+    outputStore: Optional[str] = Field(
+        default=None,
+        description="Output bucket for transcription results",
+    )
+    indexingMode: Optional[str] = Field(
+        default=None,
+        description="Indexing mode for RAG collections (e.g., HNSW, GPU_CAGRA). Auto-detected if omitted.",
+    )
 
 
 class V1CollectionResponse(BaseModel):
@@ -56,12 +66,22 @@ class V1CollectionResponse(BaseModel):
         name (str): Name of the collection.
         pipeline (str): Pipeline associated with the collection.
         buckets (Optional[List[str]]): Optional list of buckets associated with the collection.
+        outputStore (Optional[str]): Output bucket for transcription results (transcribe usecase).
+        indexingMode (Optional[str]): Indexing mode for RAG collections (e.g., HNSW, GPU_CAGRA).
     """
     name: str
     pipeline: str
     buckets: Optional[List[str]] = Field(
         default_factory=list,
         description="List of buckets associated with the collection",
+    )
+    outputStore: Optional[str] = Field(
+        default=None,
+        description="Output bucket for transcription results",
+    )
+    indexingMode: Optional[str] = Field(
+        default=None,
+        description="Indexing mode for RAG collections (e.g., HNSW, GPU_CAGRA)",
     )
 
 
@@ -87,14 +107,22 @@ class V1PipelineResponse(BaseModel):
         model (Optional[str]): Optional model associated with the pipeline.
         customFunction (Optional[str]): Optional custom function for the pipeline.
         eventFilter (Dict[str, Any]): Event filter criteria for the pipeline.
-        schema (str): Schema associated with the pipeline.
+        schema_name (str): Schema associated with the pipeline (serialized as 'schema').
+        prompt (Optional[str]): Prompt for transcribe pipelines.
+        chunkSize (Optional[int]): Chunk size for RAG pipelines.
+        chunkOverlap (Optional[int]): Chunk overlap for RAG pipelines.
     """
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
     type: str
-    model: Optional[str] = Field(default_factory=str)
-    customFunction: Optional[str] = Field(default_factory=str)
+    model: Optional[str] = Field(default=None)
+    customFunction: Optional[str] = Field(default=None)
     eventFilter: Dict[str, Any]
-    schema: str
+    schema_name: str = Field(alias="schema")
+    prompt: Optional[str] = Field(default=None, description="Prompt for transcribe pipelines")
+    chunkSize: Optional[int] = Field(default=None, description="Chunk size for RAG pipelines")
+    chunkOverlap: Optional[int] = Field(default=None, description="Chunk overlap for RAG pipelines")
 
 
 class ListCollectionItem(BaseModel):

--- a/pydi_client/data/pipeline.py
+++ b/pydi_client/data/pipeline.py
@@ -1,6 +1,6 @@
 # Copyright Hewlett Packard Enterprise Development LP
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing import List, Dict, Any, Optional
 
 
@@ -55,15 +55,32 @@ class V1CreatePipeline(BaseModel):
         type (str): Type of the pipeline.
         model (Optional[str]): Optional model associated with the pipeline.
         eventFilter (FilterItem): Event filter criteria for the pipeline.
-        schema (Optional[str]): Optional schema for the pipeline.
+        schema_name (Optional[str]): Optional schema for the pipeline (serialized as 'schema').
         customFunction (Optional[str]): Optional custom function for the pipeline.
+        prompt (Optional[str]): Prompt for transcribe pipelines (e.g., 'transcribe-metadata' type).
+        chunkSize (Optional[int]): Chunk size for RAG pipelines.
+        chunkOverlap (Optional[int]): Chunk overlap for RAG pipelines.
     """
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
     type: str
     model: Optional[str]
     eventFilter: FilterItem
-    schema: Optional[str]
+    schema_name: Optional[str] = Field(default=None, alias="schema")
     customFunction: Optional[str]
+    prompt: Optional[str] = Field(
+        default=None,
+        description="Prompt for transcribe pipelines",
+    )
+    chunkSize: Optional[int] = Field(
+        default=None,
+        description="Chunk size for RAG pipelines",
+    )
+    chunkOverlap: Optional[int] = Field(
+        default=None,
+        description="Chunk overlap for RAG pipelines",
+    )
 
 
 class V1CreatePipelineResponse(BaseModel):
@@ -119,3 +136,4 @@ class V1SimilaritySearchResponse(BaseModel):
     success: bool
     message: str
     results: Optional[List[NodeWithScore]] = Field(default_factory=list)
+

--- a/pydi_client/data/schema.py
+++ b/pydi_client/data/schema.py
@@ -1,52 +1,97 @@
 # Copyright Hewlett Packard Enterprise Development LP
 
-from pydantic import BaseModel, Field
-from typing import List
+from pydantic import BaseModel, ConfigDict, Field
+from typing import List, Optional
+
+
+class SchemaListItem(BaseModel):
+    """
+    Represents a single schema item in the list schemas response.
+
+    Attributes:
+        id (Optional[str]): Unique identifier of the schema.
+        name (str): Name of the schema.
+    """
+
+    id: Optional[str] = Field(default=None, description="schema id")
+    name: str = Field(..., description="schema name")
+
+
+class V1ListSchemasResponse(BaseModel):
+    """
+    Represents a response containing a list of schema records.
+
+    Attributes:
+        schemas (List[SchemaListItem]): List of available schemas with id and name.
+    """
+
+    schemas: List[SchemaListItem]
 
 
 class SchemaItem(BaseModel):
     """
-    Represents a schema item with a name and type.
+    Represents a single field definition inside a schema.
+
     Attributes:
-        name (str): Name of the schema field.
-        type (str): Type of the schema field.
+        name (str): Field name in the schema definition.
+        type (str): Field type in the schema definition.
     """
+
     name: str = Field(..., description="field name")
     type: str = Field(..., description="field type")
 
 
 class V1SchemasResponse(BaseModel):
     """
-    Represents a response containing schema information.
-    This model contains fields to represent the schema name, type, and a list of schema items.
+    Represents a detailed schema response.
+
+    This model contains the schema name, schema type, and the list of
+    schema fields returned by the API.
+
     Attributes:
         name (str): Name of the schema.
-        type (str): Type of the schema.
-        schema (List[SchemaItem]): List of schema fields.
+        type (Optional[str]): Schema type (for example, `rag` or `transcribe-metadata`).
+        schema_fields (List[SchemaItem]): List of schema fields (serialized as `schema`).
     """
+
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str = Field(..., description="schema name")
-    type: str = Field(..., description="schema type")
-    schema: List[SchemaItem] = Field(
+    type: Optional[str] = Field(
+        default=None,
+        description="Schema type (e.g., 'rag', 'transcribe-metadata')",
+    )
+    schema_fields: List[SchemaItem] = Field(
         ..., alias="schema", description="list of schema fields"
     )
 
 
-class SchemaRecordSummary(BaseModel):
+class V1CreateSchemaRequest(BaseModel):
     """
-    Represents a summary of a schema record.
+    Request body for creating a new schema.
+
     Attributes:
-        id (str): Unique identifier for the schema record.
-        name (str): Name of the schema record.
+        name (str): Name of the schema to create.
+        type (str): Schema type (for example, `rag` or `transcribe-metadata`).
+        schema_fields (List[SchemaItem]): List of schema fields (serialized as `schema`).
     """
-    id: str
-    name: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., description="schema name")
+    type: str = Field(..., description="schema type (e.g., 'rag', 'transcribe-metadata')")
+    schema_fields: List[SchemaItem] = Field(..., alias="schema", description="list of schema fields")
 
 
-class V1ListSchemasResponse(BaseModel):
+class V1CreateSchemaResponse(BaseModel):
     """
-    Response model for listing available schemas.
-    This model contains a list of schema records.
+    Response returned after attempting to create a schema.
+
     Attributes:
-        schemas (List[SchemaRecordSummary]): List of schema records.
+        success (Optional[bool]): Indicates whether schema creation succeeded.
+        message (Optional[str]): Additional information about the operation.
     """
-    schemas: List[SchemaRecordSummary]
+
+    success: Optional[bool] = None
+    message: Optional[str] = None
+

--- a/pydi_client/di_client.py
+++ b/pydi_client/di_client.py
@@ -364,7 +364,13 @@ class DIAdminClient(DIClient):
         return self._authenticated_session
 
     def create_collection(
-        self, *, name: str, pipeline: str, buckets: Optional[List[str]] = None
+        self,
+        *,
+        name: str,
+        pipeline: str,
+        buckets: Optional[List[str]] = None,
+        output_store: Optional[str] = None,
+        indexing_mode: Optional[str] = None,
     ) -> V1CollectionResponse:
         """
         Creates a new collection using the specified pipeline.
@@ -375,6 +381,8 @@ class DIAdminClient(DIClient):
             name (str): The name of the collection to be created. This should be unique.
             pipeline (str): The name of the pipeline to be associated with the collection.
             buckets (Optional[List[str]], optional): A list of bucket names. Defaults to None.
+            output_store (Optional[str], optional): Output bucket for transcription results. Defaults to None.
+            indexing_mode (Optional[str], optional): Indexing mode for RAG collections (supported values: 'HNSW', 'GPU_CAGRA'). Auto-detected if omitted. Defaults to None.
 
         Returns:
             V1CollectionResponse: The created collection object.
@@ -386,14 +394,16 @@ class DIAdminClient(DIClient):
             collection = client.create_collection(
                 name="example_collection",
                 pipeline="data_ingestion_pipeline",
-                buckets=["bucket1", "bucket2"]
+                buckets=["bucket1", "bucket2"],
+                output_store="output-bucket"
             )
             print(collection)
             # Sample Output:
             # V1CollectionResponse(
             #     name="example_collection",
             #     pipeline="data_ingestion_pipeline",
-            #     buckets=["bucket1", "bucket2"]
+            #     buckets=["bucket1", "bucket2"],
+            #     outputStore="output-bucket"
             # )
             ```
         """
@@ -404,6 +414,8 @@ class DIAdminClient(DIClient):
             name=name,
             buckets=buckets,
             pipeline=pipeline,
+            output_store=output_store,
+            indexing_mode=indexing_mode,
         )
 
     def delete_collection(self, *, name: str) -> V1DeleteCollectionResponse:
@@ -524,6 +536,9 @@ class DIAdminClient(DIClient):
         schema: Optional[str] = None,
         model: Optional[str] = None,
         custom_func: Optional[str] = None,
+        prompt: Optional[str] = None,
+        chunk_size: Optional[int] = None,
+        chunk_overlap: Optional[int] = None,
     ) -> V1CreatePipelineResponse:
         """
         Creates a new pipeline with the specified configuration.
@@ -536,6 +551,9 @@ class DIAdminClient(DIClient):
             event_filter_object_suffix (List[str]): A list of file suffixes to filter events. Ex - ["*.txt", "*.pdf"]
             event_filter_max_object_size (int): The maximum object size for event filtering. Ex - 10485760
             schema Optional (str): The schema definition for the pipeline.
+            prompt Optional (str): The prompt for transcribe pipelines (e.g., "Transcribe the image content into text.").
+            chunk_size Optional (int): Chunk size for RAG pipelines.
+            chunk_overlap Optional (int): Chunk overlap for RAG pipelines.
 
         Returns:
             V1CreatePipelineResponse: The response object containing details of the created pipeline.
@@ -572,6 +590,9 @@ class DIAdminClient(DIClient):
             event_filter_object_suffix=event_filter_object_suffix,
             event_filter_max_object_size=event_filter_max_object_size,
             schema=schema,
+            prompt=prompt,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
         )
 
     def delete_pipeline(self, *, name: str) -> V1DeletePipelineResponse:

--- a/tests/test_collection_api.py
+++ b/tests/test_collection_api.py
@@ -193,6 +193,41 @@ def test_create_collection_success(mocker, mock_session, collection_api):
     assert result.name == "Test Collection"
     assert result.pipeline == "default_pipeline"
     assert result.buckets == ["bucket1", "bucket2"]
+    assert result.outputStore is None
+
+
+def test_create_transcribe_collection_success(mocker, mock_session, collection_api):
+    """Test creating a transcribe collection with outputStore parameter."""
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={
+            "name": "transcribe_collection_test",
+            "pipeline": "transcribe-image-metadata",
+            "buckets": ["test-bucket-1"],
+            "outputStore": "test-bucket-1",
+            "indexingMode": "",
+        },
+    )
+    mocker.patch(
+        "pydi_client.api.collection.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_session.get_httpx_client.return_value = mock_httpx_client
+
+    result = collection_api.create_collection(
+        name="transcribe_collection_test",
+        pipeline="transcribe-image-metadata",
+        buckets=["test-bucket-1"],
+        output_store="test-bucket-1",
+    )
+
+    assert isinstance(result, V1CollectionResponse)
+    assert result.name == "transcribe_collection_test"
+    assert result.pipeline == "transcribe-image-metadata"
+    assert result.buckets == ["test-bucket-1"]
+    assert result.outputStore == "test-bucket-1"
 
 
 def test_create_collection_unauthorized(mocker, mock_session, collection_api):

--- a/tests/test_pipeline_api.py
+++ b/tests/test_pipeline_api.py
@@ -131,8 +131,74 @@ def test_get_pipeline_success(mocker, mock_session, pipeline_api):
     assert result.type == "type1"
     assert result.model == "model1"
     assert result.customFunction == "func1"
-    assert result.schema == "schema1"
+    assert result.schema_name == "schema1"
     assert result.eventFilter == {"objectSuffix": ".txt"}
+    assert result.prompt is None
+
+
+def test_create_transcribe_pipeline_success(mocker, mock_session, pipeline_api):
+    """Test creating a transcribe-metadata pipeline with prompt parameter."""
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={"success": True, "message": "transcribe-image-metadata resource created successfully."},
+    )
+    mocker.patch(
+        "pydi_client.api.pipeline.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_session.get_httpx_client.return_value = mock_httpx_client
+
+    result = pipeline_api.create_pipeline(
+        name="transcribe-image-metadata",
+        pipeline_type="transcribe-metadata",
+        model="cosmos-reason2-8b",
+        event_filter_object_suffix=["*.jpg", "*.png", "*.jpeg"],
+        event_filter_max_object_size=10737418240,
+        prompt="Transcribe the image content into text.",
+        schema="default-transcribe-metadata-schema",
+    )
+
+    assert isinstance(result, V1CreatePipelineResponse)
+    assert result.success is True
+    assert "transcribe-image-metadata" in result.message
+
+
+def test_get_transcribe_pipeline_success(mocker, mock_session, pipeline_api):
+    """Test retrieving a transcribe-metadata pipeline with prompt field."""
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={
+            "name": "transcribe-image-metadata",
+            "type": "transcribe-metadata",
+            "model": "cosmos-reason2-8b",
+            "customFunction": None,
+            "eventFilter": {
+                "objectSuffix": ["*.jpg", "*.png", "*.jpeg"],
+                "maxObjectSize": "10737418240",
+            },
+            "schema": "default-transcribe-metadata-schema",
+            "prompt": "Transcribe the image content into text.",
+        },
+    )
+    mocker.patch(
+        "pydi_client.api.pipeline.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_session.get_httpx_client.return_value = mock_httpx_client
+
+    result = pipeline_api.get_pipeline(name="transcribe-image-metadata")
+
+    assert isinstance(result, V1PipelineResponse)
+    assert result.name == "transcribe-image-metadata"
+    assert result.type == "transcribe-metadata"
+    assert result.model == "cosmos-reason2-8b"
+    assert result.schema_name == "default-transcribe-metadata-schema"
+    assert result.prompt == "Transcribe the image content into text."
+    assert result.eventFilter["objectSuffix"] == ["*.jpg", "*.png", "*.jpeg"]
 
 
 def test_get_pipeline_unauthorized(mocker, mock_session, pipeline_api):

--- a/tests/test_schema_api.py
+++ b/tests/test_schema_api.py
@@ -140,8 +140,56 @@ def test_get_schema_success(mocker, mock_authsession, schema_api):
     assert isinstance(result, V1SchemasResponse)
     assert result.name == "schema1"
     assert result.type == "metadata"
-    assert result.schema[0].name == "object_key"
-    assert result.schema[0].type == "varchar"
+    assert result.schema_fields[0].name == "object_key"
+    assert result.schema_fields[0].type == "varchar"
+
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_get_transcribe_schema_success(mocker, mock_authsession, schema_api):
+    """Test retrieving the default-transcribe-metadata-schema."""
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={
+            "name": "default-transcribe-metadata-schema",
+            "type": "transcribe-metadata",
+            "schema": [
+                {"name": "object_key", "type": "varchar"},
+                {"name": "bucket", "type": "varchar"},
+                {"name": "version_id", "type": "varchar"},
+                {"name": "size", "type": "bigint"},
+                {"name": "last_modified", "type": "timestamp"},
+                {"name": "content_type", "type": "varchar"},
+                {"name": "content_encoding", "type": "varchar"},
+                {"name": "content_language", "type": "varchar"},
+                {"name": "e_tag", "type": "varchar"},
+                {"name": "user_metadata", "type": "map(varchar, varchar)"},
+                {"name": "object_tags", "type": "map(varchar, varchar)"},
+                {"name": "transcription", "type": "varchar"},
+            ],
+        },
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    result = schema_api.get_schema(name="default-transcribe-metadata-schema")
+
+    assert isinstance(result, V1SchemasResponse)
+    assert result.name == "default-transcribe-metadata-schema"
+    assert result.type == "transcribe-metadata"
+    assert len(result.schema_fields) == 12
+    # Verify transcription field is present (specific to transcribe-metadata schema)
+    transcription_field = next(
+        (f for f in result.schema_fields if f.name == "transcription"), None
+    )
+    assert transcription_field is not None
+    assert transcription_field.type == "varchar"
 
     mock_execute_with_retry.assert_called_once()
 


### PR DESCRIPTION
**Problem:** The pydi-client SDK lacked support for Nvidia AIDP transcribe workflows. Specifically, pipeline creation had no [prompt] input for transcribe-metadata, collection creation had no [output_store] for routing transcription output, and schema/pipeline data models needed updates for newer response shapes and fields.

**Implementation:**
Pipeline: Added [prompt] to [create_pipeline()] for transcribe-metadata.
Pipeline (RAG): Added optional [chunk_size] and [chunk_overlap] to [create_pipeline()] and exposed them through [DIAdminClient.create_pipeline()].
Pipeline payload/modeling: Added alias-safe serialization for [schema], added [prompt/chunkSize/chunkOverlap] to models, and made [event_filter_max_object_size] optional in SDK requests.
Collection: Added [output_store] and [indexing_mode] to [create_collection()] and corresponding data models.
Schema: Refactored schema data models for clearer typed responses (including list/get schema structures and alias-safe field mapping).

**Testing:**
Added/updated unit tests for pipeline, collection, and schema APIs (including transcribe pipeline prompt and transcribe schema retrieval).
Manual validation performed with [DIAdminClient]: verified schema retrieval, transcribe pipeline creation/retrieval with [prompt], RAG pipeline acceptance of [chunk_size/chunk_overlap], and collection creation with [output_store].

**Changes Proposed:**
Enhance SDK pipeline methods/data objects for transcribe.
Enhance collection methods/data objects for transcribe output routing and indexing mode.
Improve schema data models for robust deserialization and clearer API contracts.

**Reviewers:**  @rajamurugan02 @shishir-shah-dev @subhakantasahoo 