### PR TITLE
SDK changes for create_schema for custom_function

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -280,7 +280,7 @@ print(results)
 ```python
     schema_response = session.create_schema(
         name="yolo-detection-schema",
-        type="custom-function",
+        schema_type="custom-function",
         schema=[
             {"name": "id", "type": "varchar"},
             {"name": "content", "type": "varchar"},

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -275,6 +275,23 @@ print(results)
 #     ...
 # ]
 ```
+## 9. Create schema
+
+```python
+    schema_response = session.create_schema(
+        name="yolo-detection-schema",
+        type="custom-function",
+        schema=[
+            {"name": "id", "type": "varchar"},
+            {"name": "content", "type": "varchar"},
+            {"name": "embedding", "type": "array(real)"},
+        ]
+    )
+```
+## 10. Delete schema
+```python
+    res = session.delete_schema(name="yolo-detection-schema")
+```
 
 ---
 

--- a/pydi_client/api/schema.py
+++ b/pydi_client/api/schema.py
@@ -1,6 +1,6 @@
 # Copyright Hewlett Packard Enterprise Development LP
 
-from typing import Any, Dict, Union, Type
+from typing import Any, Dict, List, Union, Type
 
 from pydi_client.sessions.authenticated_session import AuthenticatedSession
 from pydi_client.sessions.session import Session
@@ -8,6 +8,10 @@ from pydi_client.sessions.session import Session
 from pydi_client.data.schema import (
     V1SchemasResponse,
     V1ListSchemasResponse,
+    V1CreateSchemaRequest,
+    V1CreateSchemaResponse,
+    SchemaItem,
+    V1DeleteSchemaResponse,
 )
 
 from pydi_client.api.utils import execute_with_retry, build_response
@@ -20,6 +24,9 @@ logger = get_logger()
 class MethodFactory:
     BASE_URL = "/api/v1/schemas"
 
+    def create_schema(self):
+        return self._build("post", f"{self.BASE_URL}")
+
     def get_schema(self, name):
         return self._build("get", f"{self.BASE_URL}/{name}")
 
@@ -28,9 +35,16 @@ class MethodFactory:
 
     def _build(self, method, endpoint):
         return {"method": method, "url": endpoint}
+    
+    def delete_schema(self, name):
+        return self._build("delete", f"{self.BASE_URL}/{name}")
 
 
 class DataModelFactory:
+
+    @staticmethod
+    def create_schema() -> Type[V1CreateSchemaResponse]:
+        return V1CreateSchemaResponse
 
     @staticmethod
     def get_schema() -> Type[V1SchemasResponse]:
@@ -39,6 +53,10 @@ class DataModelFactory:
     @staticmethod
     def get_schemas() -> Type[V1ListSchemasResponse]:
         return V1ListSchemasResponse
+    
+    @staticmethod
+    def delete_schema() -> Type[V1DeleteSchemaResponse]:
+        return V1DeleteSchemaResponse
 
 
 class SchemaAPI:
@@ -52,7 +70,7 @@ class SchemaAPI:
     def __init__(self, session: Union[Session, AuthenticatedSession]):
         self._session = session
         logger.info("SchemaAPI initialized with session: %s", type(session).__name__)
-
+        
     def get_schema(self, *, name: str) -> V1SchemasResponse:
         logger.info("Retrieving schema with name: %s", name)
         kwargs: Dict[str, Any] = MethodFactory().get_schema(name)
@@ -79,4 +97,56 @@ class SchemaAPI:
         logger.info("Received response for get_models: %s", response.text)
         return build_response(
             response=response, response_cls=DataModelFactory.get_schemas()
+        )
+
+    def create_schema(
+        self,
+        *,
+        name: str,
+        type: str,
+        schema: List[SchemaItem],
+    ) -> V1CreateSchemaResponse:
+        """
+        Create a new schema
+        schema_name (str): The name of the schema
+        schema_type (str): The type of the schema
+        schemaItem (list): The keys required to create the table in trino
+        
+        """
+        logger.info("Creating schema with name: %s", name)
+        body = V1CreateSchemaRequest(name=name, type=type, schema=schema)
+        kwargs: Dict[str, Any] = MethodFactory().create_schema()
+        kwargs["json"] = body.model_dump(by_alias=True)
+
+        logger.debug("Request payload for create_schema: %s", kwargs)
+        response = execute_with_retry(
+            session=self._session,
+            request_func=self._session.get_httpx_client().request,
+            **kwargs,
+        )
+        logger.info("Schema created successfully: %s", name)
+        return build_response(
+            response=response, response_cls=DataModelFactory.create_schema()
+        )
+
+    def delete_schema(self, *, name: str) -> V1DeleteSchemaResponse:
+        """
+        Delete schema by name
+            Args:
+                schema_name (str): The name of the schema to be deleted
+            Returns:
+                Optional[Union[Any, Pipeline]]: The deleted pipeline or None if the request failed.
+        """
+        logger.info("Deleting schema with name: %s", name)
+        kwargs: Dict[str, Any] = MethodFactory().delete_schema(name=name)
+
+        logger.debug("Request payload for delete_pipeline: %s", kwargs)
+        response = execute_with_retry(
+            session=self._session,
+            request_func=self._session.get_httpx_client().request,
+            **kwargs,
+        )
+        logger.info("Deleted schema successfully: %s", name)
+        return build_response(
+            response=response, response_cls=DataModelFactory.delete_schema()
         )

--- a/pydi_client/api/schema.py
+++ b/pydi_client/api/schema.py
@@ -16,9 +16,17 @@ from pydi_client.data.schema import (
 
 from pydi_client.api.utils import execute_with_retry, build_response
 from pydi_client.logger import get_logger  # Importing the logger utility
+import httpx
+from pydantic import BaseModel
+from typing import Optional as _Optional
 
 # Initialize logger for this module
 logger = get_logger()
+
+
+class _ServerStatusResponse(BaseModel):
+    """Internal model matching the server's raw status response shape."""
+    status: _Optional[str] = None
 
 
 class MethodFactory:
@@ -124,8 +132,12 @@ class SchemaAPI:
             request_func=self._session.get_httpx_client().request,
             **kwargs,
         )
-        result = build_response(
-            response=response, response_cls=DataModelFactory.create_schema()
+        raw = build_response(response=response, response_cls=_ServerStatusResponse)
+        result = V1CreateSchemaResponse(
+            status=response.status_code,
+            message=raw.status if raw else "",
+            success=True,
+            error={},
         )
         logger.info("Schema created successfully: %s", name)
         return result
@@ -147,8 +159,12 @@ class SchemaAPI:
             request_func=self._session.get_httpx_client().request,
             **kwargs,
         )
-        result = build_response(
-            response=response, response_cls=DataModelFactory.delete_schema()
+        raw = build_response(response=response, response_cls=_ServerStatusResponse)
+        result = V1DeleteSchemaResponse(
+            status=response.status_code,
+            message=raw.status if raw else "",
+            success=True,
+            error={},
         )
         logger.info("Deleted schema successfully: %s", name)
         return result

--- a/pydi_client/api/schema.py
+++ b/pydi_client/api/schema.py
@@ -70,7 +70,7 @@ class SchemaAPI:
     def __init__(self, session: Union[Session, AuthenticatedSession]):
         self._session = session
         logger.info("SchemaAPI initialized with session: %s", type(session).__name__)
-        
+
     def get_schema(self, *, name: str) -> V1SchemasResponse:
         logger.info("Retrieving schema with name: %s", name)
         kwargs: Dict[str, Any] = MethodFactory().get_schema(name)
@@ -103,7 +103,7 @@ class SchemaAPI:
         self,
         *,
         name: str,
-        type: str,
+        schema_type: str,
         schema: List[SchemaItem],
     ) -> V1CreateSchemaResponse:
         """
@@ -114,7 +114,7 @@ class SchemaAPI:
         
         """
         logger.info("Creating schema with name: %s", name)
-        body = V1CreateSchemaRequest(name=name, type=type, schema=schema)
+        body = V1CreateSchemaRequest(name=name, type=schema_type, schema=schema)
         kwargs: Dict[str, Any] = MethodFactory().create_schema()
         kwargs["json"] = body.model_dump(by_alias=True)
 
@@ -124,10 +124,11 @@ class SchemaAPI:
             request_func=self._session.get_httpx_client().request,
             **kwargs,
         )
-        logger.info("Schema created successfully: %s", name)
-        return build_response(
+        result = build_response(
             response=response, response_cls=DataModelFactory.create_schema()
         )
+        logger.info("Schema created successfully: %s", name)
+        return result
 
     def delete_schema(self, *, name: str) -> V1DeleteSchemaResponse:
         """
@@ -135,18 +136,19 @@ class SchemaAPI:
             Args:
                 schema_name (str): The name of the schema to be deleted
             Returns:
-                Optional[Union[Any, Pipeline]]: The deleted pipeline or None if the request failed.
+                Optional[Union[Any, Schema]]: The deleted schema or None if the request failed.
         """
         logger.info("Deleting schema with name: %s", name)
         kwargs: Dict[str, Any] = MethodFactory().delete_schema(name=name)
 
-        logger.debug("Request payload for delete_pipeline: %s", kwargs)
+        logger.debug("Request payload for delete_schema: %s", kwargs)
         response = execute_with_retry(
             session=self._session,
             request_func=self._session.get_httpx_client().request,
             **kwargs,
         )
-        logger.info("Deleted schema successfully: %s", name)
-        return build_response(
+        result = build_response(
             response=response, response_cls=DataModelFactory.delete_schema()
         )
+        logger.info("Deleted schema successfully: %s", name)
+        return result

--- a/pydi_client/data/collection_manager.py
+++ b/pydi_client/data/collection_manager.py
@@ -119,7 +119,7 @@ class V1PipelineResponse(BaseModel):
     model: Optional[str] = Field(default=None)
     customFunction: Optional[str] = Field(default=None)
     eventFilter: Dict[str, Any]
-    schema_name: str = Field(alias="schema")
+    schema_name: str = Field(validation_alias="schema", serialization_alias="schema")
     prompt: Optional[str] = Field(default=None, description="Prompt for transcribe pipelines")
     chunkSize: Optional[int] = Field(default=None, description="Chunk size for RAG pipelines")
     chunkOverlap: Optional[int] = Field(default=None, description="Chunk overlap for RAG pipelines")

--- a/pydi_client/data/pipeline.py
+++ b/pydi_client/data/pipeline.py
@@ -67,7 +67,7 @@ class V1CreatePipeline(BaseModel):
     type: str
     model: Optional[str]
     eventFilter: FilterItem
-    schema_name: str = Field(alias="schema")
+    schema_name: str = Field(validation_alias="schema", serialization_alias="schema")
     customFunction: Optional[str]
     prompt: Optional[str] = Field(
         default=None,

--- a/pydi_client/data/schema.py
+++ b/pydi_client/data/schema.py
@@ -88,35 +88,31 @@ class V1CreateSchemaResponse(BaseModel):
     Response returned after attempting to create a schema.
 
     Attributes:
-        status (Optional[str]): Status string returned by the server.
-        success (Optional[bool]): Indicates whether schema creation succeeded.
+        status (int): HTTP status code of the operation.
+        message (str): Status message from the server.
+        success (bool): Indicates whether schema creation succeeded.
+        error (Dict[str, Any]): Error details if the operation fails.
     """
 
-    status: Optional[str] = Field(default=None, description="Status of the create operation")
+    status: int = Field(default=200, description="HTTP status code")
+    message: str = Field(default="", description="Status message from the server")
     success: bool = Field(default=True, description="Indicates if the create operation was successful")
+    error: Dict[str, Any] = Field(default_factory=dict, description="Error details if the operation fails")
+
 
 class V1DeleteSchemaResponse(BaseModel):
     """
-    Response model for deleting a pipeline.
-    This model contains fields to indicate the status of the delete operation,
-    any errors that occurred, and a message providing additional information.
+    Response returned after attempting to delete a schema.
 
     Attributes:
-        status (Optional[str]): Status of the delete operation.
-        Error (Optional[Dict[Any, Any]]): Error message if the delete operation fails.
-        success (Optional[bool]): Indicates if the delete operation was successful.
-        message (Optional[str]): Message providing additional information about the operation.
+        status (int): HTTP status code of the operation.
+        message (str): Status message from the server.
+        success (bool): Indicates if the delete operation was successful.
+        error (Dict[str, Any]): Error details if the delete operation fails.
     """
-    status: Optional[str] = Field(
-        default=None, description="Status of the delete operation"
-    )
-    Error: Optional[Dict[Any, Any]] = Field(
-        default_factory=dict, description="Error message if the delete operation fails"
-    )
-    success: Optional[bool] = Field(
-        default=True, description="Indicates if the delete operation was successful"
-    )
-    message: Optional[str] = Field(
-        default=None, description="Message providing additional information about the operation"
-    )
+
+    status: int = Field(default=200, description="HTTP status code")
+    message: str = Field(default="", description="Status message from the server")
+    success: bool = Field(default=True, description="Indicates if the delete operation was successful")
+    error: Dict[str, Any] = Field(default_factory=dict, description="Error details if the delete operation fails")
 

--- a/pydi_client/data/schema.py
+++ b/pydi_client/data/schema.py
@@ -103,17 +103,12 @@ class V1DeleteSchemaResponse(BaseModel):
 
     Attributes:
         status (Optional[str]): Status of the delete operation.
-        Status (Optional[str]): Alternative case for status of the delete operation.
         Error (Optional[Dict[Any, Any]]): Error message if the delete operation fails.
         success (Optional[bool]): Indicates if the delete operation was successful.
         message (Optional[str]): Message providing additional information about the operation.
     """
     status: Optional[str] = Field(
-        default_factory=str, description="Status of the delete operation"
-    )
-    Status: Optional[str] = Field(
-        default_factory=str,
-        description="Status of the delete operation (alternative case)",
+        default=None, description="Status of the delete operation"
     )
     Error: Optional[Dict[Any, Any]] = Field(
         default_factory=dict, description="Error message if the delete operation fails"

--- a/pydi_client/data/schema.py
+++ b/pydi_client/data/schema.py
@@ -88,12 +88,12 @@ class V1CreateSchemaResponse(BaseModel):
     Response returned after attempting to create a schema.
 
     Attributes:
+        status (Optional[str]): Status string returned by the server.
         success (Optional[bool]): Indicates whether schema creation succeeded.
-        message (Optional[str]): Additional information about the operation.
     """
 
-    success: Optional[bool] = None
-    message: Optional[str] = None
+    status: Optional[str] = Field(default=None, description="Status of the create operation")
+    success: bool = Field(default=True, description="Indicates if the create operation was successful")
 
 class V1DeleteSchemaResponse(BaseModel):
     """
@@ -119,7 +119,7 @@ class V1DeleteSchemaResponse(BaseModel):
         default_factory=dict, description="Error message if the delete operation fails"
     )
     success: Optional[bool] = Field(
-        default=None, description="Indicates if the delete operation was successful"
+        default=True, description="Indicates if the delete operation was successful"
     )
     message: Optional[str] = Field(
         default=None, description="Message providing additional information about the operation"

--- a/pydi_client/data/schema.py
+++ b/pydi_client/data/schema.py
@@ -1,7 +1,7 @@
 # Copyright Hewlett Packard Enterprise Development LP
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 
 
 class SchemaListItem(BaseModel):
@@ -79,8 +79,8 @@ class V1CreateSchemaRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     name: str = Field(..., description="schema name")
-    type: str = Field(..., description="schema type (e.g., 'rag', 'transcribe-metadata')")
-    schema_fields: List[SchemaItem] = Field(..., alias="schema", description="list of schema fields")
+    type: str = Field(..., description="schema type (e.g., 'custom-function')")
+    schema_fields: List[SchemaItem] = Field(..., validation_alias="schema", serialization_alias="schema", description="list of schema fields")
 
 
 class V1CreateSchemaResponse(BaseModel):
@@ -94,4 +94,34 @@ class V1CreateSchemaResponse(BaseModel):
 
     success: Optional[bool] = None
     message: Optional[str] = None
+
+class V1DeleteSchemaResponse(BaseModel):
+    """
+    Response model for deleting a pipeline.
+    This model contains fields to indicate the status of the delete operation,
+    any errors that occurred, and a message providing additional information.
+
+    Attributes:
+        status (Optional[str]): Status of the delete operation.
+        Status (Optional[str]): Alternative case for status of the delete operation.
+        Error (Optional[Dict[Any, Any]]): Error message if the delete operation fails.
+        success (Optional[bool]): Indicates if the delete operation was successful.
+        message (Optional[str]): Message providing additional information about the operation.
+    """
+    status: Optional[str] = Field(
+        default_factory=str, description="Status of the delete operation"
+    )
+    Status: Optional[str] = Field(
+        default_factory=str,
+        description="Status of the delete operation (alternative case)",
+    )
+    Error: Optional[Dict[Any, Any]] = Field(
+        default_factory=dict, description="Error message if the delete operation fails"
+    )
+    success: Optional[bool] = Field(
+        default=None, description="Indicates if the delete operation was successful"
+    )
+    message: Optional[str] = Field(
+        default=None, description="Message providing additional information about the operation"
+    )
 

--- a/pydi_client/di_client.py
+++ b/pydi_client/di_client.py
@@ -742,7 +742,7 @@ class DIAdminClient(DIClient):
         self,
         *,
         name: str,
-        type: str,
+        schema_type: str,
         schema: List[SchemaItem],
     ) -> V1CreateSchemaResponse:
         """
@@ -750,7 +750,7 @@ class DIAdminClient(DIClient):
 
         Args:
             name (str): The name of the schema to create.
-            type (str): The schema type (e.g., 'custom-function').
+            schema_type (str): The schema type (e.g., 'custom-function').
             schema (List[SchemaItem]): List of schema fields, each with a name and type.
 
         Returns:
@@ -760,7 +760,7 @@ class DIAdminClient(DIClient):
         ```python
              schema_response = client.create_schema(
                 name="yolo-detection-schema",
-                type="custom-function",
+                schema_type="custom-function",
                 schema=[{"name": "id", "type": "varchar"},
                         {"name": "content", "type": "varchar"},
                         {"name": "embedding", "type": "array(real)"},
@@ -770,7 +770,7 @@ class DIAdminClient(DIClient):
         """
         return SchemaAPI(session=self.authenticated_session).create_schema(
             name=name,
-            type=type,
+            schema_type=schema_type,
             schema=schema,
         )
 

--- a/pydi_client/di_client.py
+++ b/pydi_client/di_client.py
@@ -755,6 +755,18 @@ class DIAdminClient(DIClient):
 
         Returns:
             V1CreateSchemaResponse: Response indicating success or failure.
+        
+        Example usage
+        ```python
+             schema_response = client.create_schema(
+                name="yolo-detection-schema",
+                type="custom-function",
+                schema=[{"name": "id", "type": "varchar"},
+                        {"name": "content", "type": "varchar"},
+                        {"name": "embedding", "type": "array(real)"},
+                    ]
+            )
+        
         """
         return SchemaAPI(session=self.authenticated_session).create_schema(
             name=name,

--- a/pydi_client/di_client.py
+++ b/pydi_client/di_client.py
@@ -33,6 +33,9 @@ from pydi_client.data.model import (
 from pydi_client.data.schema import (
     V1SchemasResponse,
     V1ListSchemasResponse,
+    V1CreateSchemaResponse,
+    SchemaItem,
+    V1DeleteSchemaResponse,
 )
 
 from typing import Union, Any, List, Dict, Optional
@@ -533,7 +536,7 @@ class DIAdminClient(DIClient):
         pipeline_type: str,
         event_filter_object_suffix: List[str],
         event_filter_max_object_size: Optional[int] = None,
-        schema: Optional[str] = None,
+        schema: str,
         model: Optional[str] = None,
         custom_func: Optional[str] = None,
         prompt: Optional[str] = None,
@@ -734,3 +737,57 @@ class DIAdminClient(DIClient):
             raise e
         
         return V1ListModelsResponse(models=embedding_models_list)
+
+    def create_schema(
+        self,
+        *,
+        name: str,
+        type: str,
+        schema: List[SchemaItem],
+    ) -> V1CreateSchemaResponse:
+        """
+        Create a new schema.
+
+        Args:
+            name (str): The name of the schema to create.
+            type (str): The schema type (e.g., 'custom-function').
+            schema (List[SchemaItem]): List of schema fields, each with a name and type.
+
+        Returns:
+            V1CreateSchemaResponse: Response indicating success or failure.
+        """
+        return SchemaAPI(session=self.authenticated_session).create_schema(
+            name=name,
+            type=type,
+            schema=schema,
+        )
+
+    def delete_schema(self, *, name: str) -> V1DeleteSchemaResponse:
+        """
+        Deletes a schema with the specified name.
+
+        Args:
+            name (str): The name of the schema to be deleted.
+
+        Returns:
+            V1DeleteSchemaResponse: The response object containing details about the deleted schema.
+
+        Example usage:
+            ```python
+            # Initialize the DIAdminClient
+            client = DIAdminClient(uri="http://example.com", username="admin", password="password")
+
+            # Delete a schema by name
+            response = client.delete_schema(name="example_schema")
+            print(response)
+            # Output:
+            # V1DeleteSchemaResponse(
+            #     message="Schema successfully deleted"
+            #     success=True,
+            # )
+            ```
+        """
+        return SchemaAPI(session=self.authenticated_session).delete_schema(
+            name=name
+        )
+    

--- a/tests/test_schema_api.py
+++ b/tests/test_schema_api.py
@@ -262,8 +262,10 @@ def test_create_schema_success(mocker, mock_authsession, schema_api):
     )
 
     assert isinstance(result, V1CreateSchemaResponse)
-    assert result.status == "Schema 'yolo-detection-schema' created successfully"
+    assert result.status == 200
+    assert result.message == "Schema 'yolo-detection-schema' created successfully"
     assert result.success is True
+    assert result.error == {}
     mock_execute_with_retry.assert_called_once()
 
 
@@ -331,8 +333,10 @@ def test_delete_schema_success(mocker, mock_authsession, schema_api):
     result = schema_api.delete_schema(name="yolo-detection-schema")
 
     assert isinstance(result, V1DeleteSchemaResponse)
-    assert result.status == "Schema 'yolo-detection-schema' deleted successfully"
+    assert result.status == 200
+    assert result.message == "Schema 'yolo-detection-schema' deleted successfully"
     assert result.success is True
+    assert result.error == {}
     mock_execute_with_retry.assert_called_once()
 
 

--- a/tests/test_schema_api.py
+++ b/tests/test_schema_api.py
@@ -13,6 +13,8 @@ from pydi_client.api.schema import SchemaAPI
 from pydi_client.data.schema import (
     V1SchemasResponse,
     V1ListSchemasResponse,
+    V1CreateSchemaResponse,
+    V1DeleteSchemaResponse,
 )
 
 
@@ -231,5 +233,143 @@ def test_get_schema_unexpected_status(mocker, mock_authsession, schema_api):
 
     with pytest.raises(UnexpectedStatus):
         schema_api.get_schema(name="schema1")
+
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_create_schema_success(mocker, mock_authsession, schema_api):
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={"status": "Schema 'yolo-detection-schema' created successfully"},
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    result = schema_api.create_schema(
+        name="yolo-detection-schema",
+        schema_type="custom-function",
+        schema=[
+            {"name": "id", "type": "varchar"},
+            {"name": "content", "type": "varchar"},
+            {"name": "embedding", "type": "array(real)"},
+        ],
+    )
+
+    assert isinstance(result, V1CreateSchemaResponse)
+    assert result.status == "Schema 'yolo-detection-schema' created successfully"
+    assert result.success is True
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_create_schema_unauthorized(mocker, mock_authsession, schema_api):
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.UNAUTHORIZED, json={"detail": "Unauthorized"}
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    with pytest.raises(HTTPUnauthorizedException):
+        schema_api.create_schema(
+            name="yolo-detection-schema",
+            schema_type="custom-function",
+            schema=[{"name": "id", "type": "varchar"}],
+        )
+
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_create_schema_unexpected_status(mocker, mock_authsession, schema_api):
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        json={"detail": "Internal Server Error"},
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    with pytest.raises(UnexpectedStatus):
+        schema_api.create_schema(
+            name="yolo-detection-schema",
+            schema_type="custom-function",
+            schema=[{"name": "id", "type": "varchar"}],
+        )
+
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_delete_schema_success(mocker, mock_authsession, schema_api):
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={"status": "Schema 'yolo-detection-schema' deleted successfully"},
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    result = schema_api.delete_schema(name="yolo-detection-schema")
+
+    assert isinstance(result, V1DeleteSchemaResponse)
+    assert result.status == "Schema 'yolo-detection-schema' deleted successfully"
+    assert result.success is True
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_delete_schema_unauthorized(mocker, mock_authsession, schema_api):
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.UNAUTHORIZED, json={"detail": "Unauthorized"}
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    with pytest.raises(HTTPUnauthorizedException):
+        schema_api.delete_schema(name="yolo-detection-schema")
+
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_delete_schema_unexpected_status(mocker, mock_authsession, schema_api):
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        json={"detail": "Internal Server Error"},
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    with pytest.raises(UnexpectedStatus):
+        schema_api.delete_schema(name="yolo-detection-schema")
 
     mock_execute_with_retry.assert_called_once()


### PR DESCRIPTION
Problem:
Customer should be able to create and delete schema

Implementation:
SDK changes of create_schema() and delete_schema() for Custom-function

Test Results:

1. Create a schema and check if successful
2. Delete an existing schema and check is successful
3. Try to create schema without giving name
4. Try to create schema without mentioning the type
5. Try to create schema without providing the schema list
6. Create a custom function pipeline by giving the schema created earlier
7. Create custom function pipeline, by giving incorrect model name
8. Create custom function pipeline, without giving model name
9. Create custom function pipeline, by giving different object suffixes
10. Create custom function pipeline, by not giving object suffixes
11. Create custom function pipeline by giving incorrect pipeline type
12. Create custom function pipeline by not giving pipeline type
13. Create custom function pipeline with incorrect schema name
14. Create custom function pipeline without schema name


**1) Check if delete_chema() and create_schema() function is available**

In [1]: from pydi_client import DIAdminClient

> In [2]: session = DIAdminClient(uri='https://localhost:31443', username='admin', password='Nim123Boli')
> 
> In [3]: dir(session)
> Out[3]: 
> ['__class__',
>  '__delattr__',
>  '__dict__',
>  '__dir__',
>  '__doc__',
>  '__eq__',
>  '__format__',
>  '__ge__',
>  '__getattribute__',
>  '__getstate__',
>  '__gt__',
>  '__hash__',
>  '__init__',
>  '__init_subclass__',
>  '__le__',
>  '__lt__',
>  '__module__',
>  '__ne__',
>  '__new__',
>  '__reduce__',
>  '__reduce_ex__',
>  '__repr__',
>  '__setattr__',
>  '__sizeof__',
>  '__str__',
>  '__subclasshook__',
>  '__weakref__',
>  '_authenticated_session',
>  '_session',
>  'assign_buckets_to_collection',
>  'authenticated_session',
>  'create_collection',
>  'create_pipeline',
>  'create_schema',
>  'delete_collection',
>  'delete_pipeline',
>  'delete_schema',
>  'get_all_collections',
>  'get_all_embedding_models',
>  'get_all_models',
>  'get_all_pipelines',
>  'get_all_schemas',
>  'get_collection',
>  'get_embedding_model',
>  'get_model',
>  'get_pipeline',
>  'get_schema',
>  'session',
>  'similarity_search',
>  'unassign_buckets_from_collection']
> 

**2) Create a schema and check if it is available:**

> In [8]: res = session.create_schema(
>    ...:     name="yolo-detection--schema",
>    ...:     type="custom-function",
>    ...:     schema=[
>    ...:         {"name": "id", "type": "varchar"},
>    ...:         {"name": "content", "type": "varchar"},
>    ...:         {"name": "embedding", "type": "array(real)"},
>    ...:     ]
>    ...: )

> In [9]: res = session.get_all_schemas()
> 
> In [10]: print(res)
> schemas=[SchemaListItem(id='881be32a-1d2d-4ab5-b03c-3071ae6b21c8', name='default-rag-schema'), SchemaListItem(id='f4ef6998-4695-4ba0-90f6-9a3c1db7afa5', name='default-metadata-schema'), SchemaListItem(id='043f3edc-2225-461b-9aa8-d06de0a3adda', name='default-rag-storage-efficient-schema'), SchemaListItem(id='130d8529-0f97-4f0b-aeb8-82dd8a42d07a', name='my-schema'), SchemaListItem(id='58ff752a-f82c-40d6-b259-ca4381e74a02', **name='yolo-detection--schema'**)]


3) Delete schema by name and check if it got delete sucessfully

> In [1]: from pydi_client import DIAdminClient
> 
> In [2]: session = DIAdminClient(uri='https://localhost:31443', username='admin', password='Nim123Boli')
> 
> In [3]: res = session.delete_schema(name="yolo-detection--schema")
> 
> In [4]: res = session.get_all_schemas()
> 
> In [5]: print(res)
> schemas=[SchemaListItem(id='881be32a-1d2d-4ab5-b03c-3071ae6b21c8', name='default-rag-schema'), SchemaListItem(id='f4ef6998-4695-4ba0-90f6-9a3c1db7afa5', name='default-metadata-schema'), SchemaListItem(id='043f3edc-2225-461b-9aa8-d06de0a3adda', name='default-rag-storage-efficient-schema'), SchemaListItem(id='130d8529-0f97-4f0b-aeb8-82dd8a42d07a', name='my-schema')]


4) Try to create schema without giving name

> In [9]: # Try to create schema without giving name
> 
> In [10]: schema_response = session.create_schema(
>     ...:         type="custom-function",
>     ...:         schema=[
>     ...:             {"name": "id", "type": "varchar"},
>     ...:             {"name": "content", "type": "varchar"},
>     ...:             {"name": "embedding", "type": "array(real)"},
>     ...:         ]
>     ...:     )
> 
> TypeError: DIAdminClient.create_schema() missing 1 required keyword-only argument: 'name'

5) Try to create schema without mentioning the type

> In [11]: # Try to create schema without giving type
> 
> In [12]: schema_response = session.create_schema(
>     ...:         name="yolo-detection-schema-no-type",
>     ...:         schema=[
>     ...:             {"name": "id", "type": "varchar"},
>     ...:             {"name": "content", "type": "varchar"},
>     ...:             {"name": "embedding", "type": "array(real)"},
>     ...:         ]
>     ...:     )
> 
> TypeError: DIAdminClient.create_schema() missing 1 required keyword-only argument: 'type'

6) Try to create schema without providing the schema list

> In [13]: schema_response = session.create_schema(
>     ...:         name="yolo-detection-schema-no-schema-list",
>     ...:         schema=[
>     ...:             {"name": "id", "type": "varchar"},
>     ...:             {"name": "content", "type": "varchar"},
>     ...:             {"name": "embedding", "type": "array(real)"},
>     ...:         ]
>     ...:     )
> 
> TypeError: DIAdminClient.create_schema() missing 1 required keyword-only argument: 'schema'

7) Create a custom function pipeline by giving the schema created earlier

> In [18]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline", model="di-custom-function-model", event_filter_object_suffix=["*.jpg"], pipeline_type="custom-function", schema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> In [20]: res = session.get_all_pipelines()
> 
> In [21]: print(res)
> root=[ListPipeline(id='51abc361-c5d2-416e-ab38-2a88156edfa4', name='default-rag-pipeline'), ListPipeline(id='a5d66d9a-4d0b-4668-a004-4a7f1f4deaba', name='default-metadata-pipeline'), ListPipeline(id='77e011e9-3bcc-46c7-bdd2-4b20fbc1dbc6', name='yolo-detection-pipeline'), ListPipeline(id='1e7ed82d-ac44-499d-be27-f86be8f22d86', name='different-files-pipeline'), ListPipeline(id='ef78cec2-3cf6-41e0-a75e-66d9731beb92', name='maxobject-pipeline1'), ListPipeline(id='17851be4-c7f7-4dfd-b9c5-c6db75ea4683', name='my-custom-function-pipeline')]

8) Create custom function pipeline, by giving incorrect model name

> In [22]: # Create custom function pipeline, by giving incorrect model name
> 
> In [23]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline", model="nomic-performance-model", event_filter_object_suffix=["*.jpg"], pipel
>        ⋮ ine_type="custom-function", schema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")

> UnexpectedStatus: Unexpected status code: 422
> 
> Response content:
> {"Status": "Model 'nomic-performance-model' is not valid for custom function pipeline", "error": "Model must have 'Custom-Function' capability"}

9) Create custom function pipeline, without giving model name
I

> n [24]: # Create custom function pipeline, without giving model name
> 
> In [25]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline12", event_filter_object_suffix=["*.jpg"], pipeline_type="custom-function", sch
>        ⋮ ema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> UnexpectedStatus: Unexpected status code: 422
> 
> Response content:
> {"Status": "invalid payload", "errors": [{"type": "missing", "loc": ["custom-function", "model"], "msg": "Field required", "input": {"name": "my-custom-function-pipeline12", "type": "custom-function", "eventFilter": {"objectSuffix": ["*.jpg"], "maxObjectSize": 10485760}, "schema": "yolo-detection-schema", "chunkSize": 512, "chunkOverlap": 50}}]}

10) Create pipeline by giving different object suffixes

> In [26]: # Create custom function pipeline, by giving incorrect object_suffix
> 
> In [27]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline11", model="di-custom-function-model", event_filter_object_suffix=["*.mp4"], pi
>        ⋮ peline_type="custom-function", schema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> In [28]: 
> 
> In [28]: 
> 
> In [28]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline112", model="di-custom-function-model", event_filter_object_suffix=["*.pdf"], p
>        ⋮ ipeline_type="custom-function", schema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> In [29]: res = session.get_all_pipelines()
> 
> In [30]: print(res)
> root=[ListPipeline(id='51abc361-c5d2-416e-ab38-2a88156edfa4', name='default-rag-pipeline'), ListPipeline(id='a5d66d9a-4d0b-4668-a004-4a7f1f4deaba', name='default-metadata-pipeline'), ListPipeline(id='77e011e9-3bcc-46c7-bdd2-4b20fbc1dbc6', name='yolo-detection-pipeline'), ListPipeline(id='1e7ed82d-ac44-499d-be27-f86be8f22d86', name='different-files-pipeline'), ListPipeline(id='ef78cec2-3cf6-41e0-a75e-66d9731beb92', name='maxobject-pipeline1'), ListPipeline(id='17851be4-c7f7-4dfd-b9c5-c6db75ea4683', name='my-custom-function-pipeline'), ListPipeline(id='351e74e3-65d7-41d0-81ed-9ff7abacdd60', name='my-custom-function-pipeline11'), ListPipeline(id='9bf0e4aa-6d17-498f-a774-f8f6dc3d6623', name='my-custom-function-pipeline112')]

11) Create pipeline by not providing object suffix

> In [31]: # Create custom function pipeline, by without giving object_suffix
> 
> In [32]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline123", model="di-custom-function-model", pipeline_type="custom-function", schema
> 
> TypeError: DIAdminClient.create_pipeline() missing 1 required keyword-only argument: 'event_filter_object_suffix'

12)  Create pipeline by giving incorrect pipeline type

> In [33]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline112", model="di-custom-function-model", event_filter_object_suffix=["*.pdf"], pipeline_type="metadata", schema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> UnexpectedStatus: Unexpected status code: 400
> 
> Response content:
> {"Status": "Schema 'yolo-detection-schema' is not valid for metadata pipelines", "error": "Schema type 'custom-function' does not match required type 'metadata'"}

13) Create pipeline by not giving pipeline type

> In [34]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline112", model="di-custom-function-model", event_filter_object_suffix=["*.pdf"], s
>        ⋮ chema="yolo-detection-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> TypeError: DIAdminClient.create_pipeline() missing 1 required keyword-only argument: 'pipeline_type'

14) Create a pipeline by giving incorrect schema

> In [36]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline112", model="di-custom-function-model", event_filter_object_suffix=["*.pdf"], p
>        ⋮ ipeline_type="custom-function", schema="default-rag-schema", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> UnexpectedStatus: Unexpected status code: 400
> 
> Response content:
> {"Status": "Schema 'default-rag-schema' is not valid for custom-function pipelines", "error": "Schema type 'rag' does not match required type 'custom-function'"}

15) Create pipeline by not providing schema

> In [3]: pipeline1 = session.create_pipeline(name="my-custom-function-pipeline112", model="di-custom-function-model", event_filter_object_suffix=["*.pdf"], pipeline_type="custom-function", chunk_size="512", chunk_overlap="50", event_filter_max_object_size="10485760")
> 
> TypeError: DIAdminClient.create_pipeline() missing 1 required keyword-only argument: 'schema'