### PR TITLE
Enhance create_schema to support optional/nullable fields

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -288,6 +288,20 @@ print(results)
         ]
     )
 ```
+
+You can optionally mark individual fields as required by setting `nullable: False`. Fields with `nullable: False` are created as `NOT NULL` in the database and validated strictly, while fields where `nullable` is omitted default to `True` (non-strict validation).
+
+```python
+    schema_response = session.create_schema(
+        name="yolo-detection-schema",
+        schema_type="custom-function",
+        schema=[
+            {"name": "id", "type": "varchar", "nullable": False},   # required
+            {"name": "content", "type": "varchar"},                 # optional (nullable=True)
+            {"name": "embedding", "type": "array(real)"},           # optional (nullable=True)
+        ]
+    )
+```
 ## 10. Delete schema
 ```python
     res = session.delete_schema(name="yolo-detection-schema")

--- a/pydi_client/api/schema.py
+++ b/pydi_client/api/schema.py
@@ -118,8 +118,11 @@ class SchemaAPI:
         Create a new schema
         schema_name (str): The name of the schema
         schema_type (str): The type of the schema
-        schemaItem (list): The keys required to create the table in trino
-        
+        schemaItem (list): The keys required to create the table in the database.
+            Each field may include an optional ``nullable`` flag (defaults to
+            ``True``). Set ``nullable`` to ``False`` to mark a field as
+            required (``NOT NULL`` in the database, strict schema validation).
+
         """
         logger.info("Creating schema with name: %s", name)
         body = V1CreateSchemaRequest(name=name, type=schema_type, schema=schema)

--- a/pydi_client/data/schema.py
+++ b/pydi_client/data/schema.py
@@ -35,10 +35,17 @@ class SchemaItem(BaseModel):
     Attributes:
         name (str): Field name in the schema definition.
         type (str): Field type in the schema definition.
+        nullable (bool): Whether the field allows null values. Defaults to
+            ``True``. Set to ``False`` to mark the field as required (the
+            underlying database column is created as ``NOT NULL`` and schema
+            validation is strict for that field).
     """
 
     name: str = Field(..., description="field name")
     type: str = Field(..., description="field type")
+    nullable: bool = Field(
+        default=True, description="whether the field allows null values"
+    )
 
 
 class V1SchemasResponse(BaseModel):

--- a/pydi_client/di_client.py
+++ b/pydi_client/di_client.py
@@ -751,22 +751,29 @@ class DIAdminClient(DIClient):
         Args:
             name (str): The name of the schema to create.
             schema_type (str): The schema type (e.g., 'custom-function').
-            schema (List[SchemaItem]): List of schema fields, each with a name and type.
+            schema (List[SchemaItem]): List of schema fields. Each field has a
+                ``name`` and ``type``, and may optionally include a ``nullable``
+                flag (defaults to ``True``). Set ``nullable`` to ``False`` to
+                mark a field as required: the underlying database column is created
+                as ``NOT NULL`` and schema validation is strict for that field,
+                while fields left as ``nullable=True`` are validated non-strictly.
 
         Returns:
             V1CreateSchemaResponse: Response indicating success or failure.
-        
+
         Example usage
         ```python
              schema_response = client.create_schema(
                 name="yolo-detection-schema",
                 schema_type="custom-function",
-                schema=[{"name": "id", "type": "varchar"},
+                schema=[{"name": "id", "type": "varchar", "nullable": False},
                         {"name": "content", "type": "varchar"},
-                        {"name": "embedding", "type": "array(real)"},
+                        {"name": "embedding", "type": "array(real)", "nullable": True},
                     ]
             )
-        
+            # "id" is required (NOT NULL, strict validation); "content" and
+            # "embedding" allow nulls (nullable defaults to True when omitted).
+
         """
         return SchemaAPI(session=self.authenticated_session).create_schema(
             name=name,

--- a/tests/test_schema_api.py
+++ b/tests/test_schema_api.py
@@ -148,6 +148,39 @@ def test_get_schema_success(mocker, mock_authsession, schema_api):
     mock_execute_with_retry.assert_called_once()
 
 
+def test_get_schema_parses_nullable(mocker, mock_authsession, schema_api):
+    """The nullable flag is parsed from the response, defaulting to True when absent."""
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={
+            "name": "schema1",
+            "type": "metadata",
+            "schema": [
+                {"name": "field1", "type": "varchar", "nullable": True},
+                {"name": "field2", "type": "varchar", "nullable": False},
+                {"name": "field3", "type": "varchar"},  # omitted -> defaults True
+            ],
+        },
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    result = schema_api.get_schema(name="schema1")
+
+    assert isinstance(result, V1SchemasResponse)
+    assert result.schema_fields[0].nullable is True
+    assert result.schema_fields[1].nullable is False
+    assert result.schema_fields[2].nullable is True
+
+    mock_execute_with_retry.assert_called_once()
+
+
 def test_get_transcribe_schema_success(mocker, mock_authsession, schema_api):
     """Test retrieving the default-transcribe-metadata-schema."""
     mock_response = HTTPXResponse(
@@ -266,6 +299,45 @@ def test_create_schema_success(mocker, mock_authsession, schema_api):
     assert result.message == "Schema 'yolo-detection-schema' created successfully"
     assert result.success is True
     assert result.error == {}
+    mock_execute_with_retry.assert_called_once()
+
+
+def test_create_schema_with_nullable_fields(mocker, mock_authsession, schema_api):
+    """Fields may declare a ``nullable`` flag which is sent in the request body."""
+    mock_response = HTTPXResponse(
+        status_code=HTTPStatus.OK,
+        json={"status": "Schema 'mixed-nullable-schema' created successfully"},
+    )
+
+    mock_execute_with_retry = mocker.patch(
+        "pydi_client.api.schema.execute_with_retry", return_value=mock_response
+    )
+
+    mock_httpx_client = mocker.MagicMock()
+    mock_httpx_client.request.return_value = mock_response
+    mock_authsession.get_httpx_client.return_value = mock_httpx_client
+
+    result = schema_api.create_schema(
+        name="mixed-nullable-schema",
+        schema_type="custom-function",
+        schema=[
+            {"name": "field1", "type": "varchar", "nullable": True},
+            {"name": "field2", "type": "varchar", "nullable": False},
+            {"name": "field3", "type": "varchar"},  # defaults to nullable=True
+        ],
+    )
+
+    assert isinstance(result, V1CreateSchemaResponse)
+    assert result.status == 200
+
+    # Verify the serialized request body carries the nullable flag for each field.
+    _, kwargs = mock_execute_with_retry.call_args
+    sent_schema = kwargs["json"]["schema"]
+    assert sent_schema == [
+        {"name": "field1", "type": "varchar", "nullable": True},
+        {"name": "field2", "type": "varchar", "nullable": False},
+        {"name": "field3", "type": "varchar", "nullable": True},
+    ]
     mock_execute_with_retry.assert_called_once()
 
 


### PR DESCRIPTION
## Problem
Schema fields couldn't be marked as required — every field was implicitly nullable, with no way to enforce `NOT NULL` or strict validation.

## Summary of changes
- Added an optional `nullable` flag (default `True`) to schema fields in `create_schema`.
- `nullable: False` → required field (`NOT NULL`, strict validation); omitted/`True` → optional (non-strict).
- Updated docstrings and the tutorial; added tests.

## Implementation
- `SchemaItem`: new `nullable: bool = True` field, serialized on create and parsed on get.
- `SchemaAPI.create_schema` / `DIAdminClient.create_schema`: pass the flag through and document it.
- Tests cover request serialization and response defaulting.